### PR TITLE
Enable numlock on boot

### DIFF
--- a/install
+++ b/install
@@ -11,6 +11,10 @@ echo Installing Iceweasel
 echo
 sudo apt-get -y --force-yes install iceweasel
 echo
+echo Installing numlockx (to automatically enable numlock on boot)
+echo
+sudo apt-get -y --force-yes install numlockx
+echo
 echo Installing Arduino IDE
 echo
 sudo apt-get -y --force-yes install arduino


### PR DESCRIPTION
Maybe it's just me, but the numpad is vitally important.

Not actually tested on a pi, works on Ubuntu and Debian Jessie apparently!
